### PR TITLE
#61 print statement in FileApiBase.commandJson should respect ignore_errors flag

### DIFF
--- a/smartlingApiSdk/ApiV2.py
+++ b/smartlingApiSdk/ApiV2.py
@@ -34,13 +34,13 @@ class ApiV2(FileApiBase):
     hostStg = 'api.stg.smartling.net'
     clientUid = "{\"client\":\"smartling-api-sdk-python\",\"version\":\"%s\"}" % version
 
-    def __init__(self, userIdentifier, userSecret, projectId, proxySettings=None, permanentHeaders={}, env='prod'):
+    def __init__(self, userIdentifier, userSecret, projectId, proxySettings=None, permanentHeaders={}, env='prod', ignore_errors=False):
         self.host = self.hostProd
         self.userIdentifier = userIdentifier
         if 'stg'==env:
             self.host = self.hostStg
-        FileApiBase.__init__(self, self.host, userIdentifier, userSecret, proxySettings, permanentHeaders=permanentHeaders)
-        self.authClient = AuthClient(self.host, userIdentifier, userSecret, proxySettings)
+        FileApiBase.__init__(self, self.host, userIdentifier, userSecret, proxySettings, permanentHeaders=permanentHeaders, ignore_errors=ignore_errors)
+        self.authClient = AuthClient(self.host, userIdentifier, userSecret, proxySettings, ignore_errors=ignore_errors)
         self.urlHelper = UrlV2Helper(projectId)
 
     def addAuth(self, params):

--- a/smartlingApiSdk/AuthClient.py
+++ b/smartlingApiSdk/AuthClient.py
@@ -29,8 +29,8 @@ class AuthClient:
     refreshUri = "/auth-api/v2/authenticate/refresh"
     timeJitter = 5  # Seconds off server expiration time
 
-    def __init__(self, host, userIdentifier, userSecret, proxySettings=None):
-        self.httpClient = HttpClient(host, proxySettings)
+    def __init__(self, host, userIdentifier, userSecret, proxySettings=None, ignore_errors=False):
+        self.httpClient = HttpClient(host, proxySettings, ignore_errors=ignore_errors)
         self.userIdentifier = userIdentifier
         self.userSecret = userSecret
         self.accessExpiresAt = 0

--- a/smartlingApiSdk/FileApiBase.py
+++ b/smartlingApiSdk/FileApiBase.py
@@ -35,12 +35,13 @@ class FileApiBase:
     """ basic class implementing low-level api calls """
     response_as_string = False
 
-    def __init__(self, host, apiKey, projectId, proxySettings=None, permanentHeaders={}):
+    def __init__(self, host, apiKey, projectId, proxySettings=None, permanentHeaders={}, ignore_errors=False):
         self.host = host
         self.apiKey = apiKey
         self.projectId = projectId
         self.proxySettings = proxySettings
-        self.httpClient = HttpClient(host, proxySettings, permanentHeaders=permanentHeaders)
+        self.ignore_errors = ignore_errors
+        self.httpClient = HttpClient(host, proxySettings, permanentHeaders=permanentHeaders, ignore_errors=ignore_errors)
         if Settings.printToLogfile:
             sys.stdout = Logger('python-sdk', Settings.logLevel, Settings.logPath)
             sys.stderr = Logger('STDERR', logging.ERROR, Settings.logPath)
@@ -94,7 +95,7 @@ class FileApiBase:
         jsonBody = json.dumps(params).encode('utf8')
 
         data, code, headers = self.httpClient.getHttpResponseAndStatus(method, uri, params={}, requestBody = jsonBody, extraHeaders = authHeader)
-        if not code in [200,202]:
+        if not code in [200,202] and not self.ignore_errors:
             rId = headers.get("X-SL-RequestId","Unknown")
             print ("code:%d RequestId:%s jsonBody=%s" % (code, rId, jsonBody))
 

--- a/smartlingApiSdk/HttpClient.py
+++ b/smartlingApiSdk/HttpClient.py
@@ -39,11 +39,11 @@ import ssl
 class HttpClient:
     protocol = 'https://'
 
-    def __init__(self, host, proxySettings=None, permanentHeaders={}):
+    def __init__(self, host, proxySettings=None, permanentHeaders={}, ignore_errors=False):
         self.host = host
         self.proxySettings = proxySettings
         self.permanentHeaders = permanentHeaders
-        self.ignore_errors = False
+        self.ignore_errors = ignore_errors
         self.list_brackets = True  # Add [] suffix to GET list keys in urls, like &hashcodes[]=abcd, required by Files API
         self.force_multipart = True
 

--- a/smartlingApiSdk/api/AccountProjectsApi.py
+++ b/smartlingApiSdk/api/AccountProjectsApi.py
@@ -23,8 +23,8 @@ from smartlingApiSdk.ApiV2 import ApiV2
 
 class AccountProjectsApi(ApiV2):
 
-    def __init__(self, userIdentifier, userSecret, projectId, proxySettings=None, permanentHeaders={}, env='prod'):
-        ApiV2.__init__(self, userIdentifier, userSecret, projectId, proxySettings, permanentHeaders=permanentHeaders, env=env)
+    def __init__(self, userIdentifier, userSecret, projectId, proxySettings=None, permanentHeaders={}, env='prod', ignore_errors=False):
+        ApiV2.__init__(self, userIdentifier, userSecret, projectId, proxySettings, permanentHeaders=permanentHeaders, env=env, ignore_errors=ignore_errors)
 
     def getProjectsByAccount(self, accountUid, projectNameFilter='', includeArchived='', offset=0, limit=0, projectTypeCode='', projectTypeCodes=[], **kwargs):
         """

--- a/smartlingApiSdk/api/ContextApi.py
+++ b/smartlingApiSdk/api/ContextApi.py
@@ -23,8 +23,8 @@ from smartlingApiSdk.ApiV2 import ApiV2
 
 class ContextApi(ApiV2):
 
-    def __init__(self, userIdentifier, userSecret, projectId, proxySettings=None, permanentHeaders={}, env='prod'):
-        ApiV2.__init__(self, userIdentifier, userSecret, projectId, proxySettings, permanentHeaders=permanentHeaders, env=env)
+    def __init__(self, userIdentifier, userSecret, projectId, proxySettings=None, permanentHeaders={}, env='prod', ignore_errors=False):
+        ApiV2.__init__(self, userIdentifier, userSecret, projectId, proxySettings, permanentHeaders=permanentHeaders, env=env, ignore_errors=ignore_errors)
 
     def uploadNewVisualContext(self, name='', content='', **kwargs):
         """

--- a/smartlingApiSdk/api/EstimatesApi.py
+++ b/smartlingApiSdk/api/EstimatesApi.py
@@ -23,8 +23,8 @@ from smartlingApiSdk.ApiV2 import ApiV2
 
 class EstimatesApi(ApiV2):
 
-    def __init__(self, userIdentifier, userSecret, projectId, proxySettings=None, permanentHeaders={}, env='prod'):
-        ApiV2.__init__(self, userIdentifier, userSecret, projectId, proxySettings, permanentHeaders=permanentHeaders, env=env)
+    def __init__(self, userIdentifier, userSecret, projectId, proxySettings=None, permanentHeaders={}, env='prod', ignore_errors=False):
+        ApiV2.__init__(self, userIdentifier, userSecret, projectId, proxySettings, permanentHeaders=permanentHeaders, env=env, ignore_errors=ignore_errors)
 
     def getJobFuzzyEstimateReports(self, translationJobUid, reportStatus='', contentCoverage='', creatorUserUids=[], translationJobSchemaContents=[], tags=[], createdFrom='', createdTo='', limit=0, offset=0, **kwargs):
         """

--- a/smartlingApiSdk/api/FilesApi.py
+++ b/smartlingApiSdk/api/FilesApi.py
@@ -23,8 +23,8 @@ from smartlingApiSdk.ApiV2 import ApiV2
 
 class FilesApi(ApiV2):
 
-    def __init__(self, userIdentifier, userSecret, projectId, proxySettings=None, permanentHeaders={}, env='prod'):
-        ApiV2.__init__(self, userIdentifier, userSecret, projectId, proxySettings, permanentHeaders=permanentHeaders, env=env)
+    def __init__(self, userIdentifier, userSecret, projectId, proxySettings=None, permanentHeaders={}, env='prod', ignore_errors=False):
+        ApiV2.__init__(self, userIdentifier, userSecret, projectId, proxySettings, permanentHeaders=permanentHeaders, env=env, ignore_errors=ignore_errors)
 
     def uploadSourceFile(self, file, fileUri, fileType, callbackUrl='', directives={}, **kwargs):
         """

--- a/smartlingApiSdk/api/JobBatchesV2Api.py
+++ b/smartlingApiSdk/api/JobBatchesV2Api.py
@@ -23,8 +23,8 @@ from smartlingApiSdk.ApiV2 import ApiV2
 
 class JobBatchesV2Api(ApiV2):
 
-    def __init__(self, userIdentifier, userSecret, projectId, proxySettings=None, permanentHeaders={}, env='prod'):
-        ApiV2.__init__(self, userIdentifier, userSecret, projectId, proxySettings, permanentHeaders=permanentHeaders, env=env)
+    def __init__(self, userIdentifier, userSecret, projectId, proxySettings=None, permanentHeaders={}, env='prod', ignore_errors=False):
+        ApiV2.__init__(self, userIdentifier, userSecret, projectId, proxySettings, permanentHeaders=permanentHeaders, env=env, ignore_errors=ignore_errors)
 
     def createJobBatchV2(self, authorize, translationJobUid, fileUris, localeWorkflows=[], **kwargs):
         """

--- a/smartlingApiSdk/api/JobsApi.py
+++ b/smartlingApiSdk/api/JobsApi.py
@@ -23,8 +23,8 @@ from smartlingApiSdk.ApiV2 import ApiV2
 
 class JobsApi(ApiV2):
 
-    def __init__(self, userIdentifier, userSecret, projectId, proxySettings=None, permanentHeaders={}, env='prod'):
-        ApiV2.__init__(self, userIdentifier, userSecret, projectId, proxySettings, permanentHeaders=permanentHeaders, env=env)
+    def __init__(self, userIdentifier, userSecret, projectId, proxySettings=None, permanentHeaders={}, env='prod', ignore_errors=False):
+        ApiV2.__init__(self, userIdentifier, userSecret, projectId, proxySettings, permanentHeaders=permanentHeaders, env=env, ignore_errors=ignore_errors)
 
     def getJobsByAccount(self, accountUid, jobName='', projectIds=[], translationJobStatus=[], withPriority='', limit=0, offset=0, sortBy='', sortDirection='', **kwargs):
         """

--- a/smartlingApiSdk/api/StringsApi.py
+++ b/smartlingApiSdk/api/StringsApi.py
@@ -23,8 +23,8 @@ from smartlingApiSdk.ApiV2 import ApiV2
 
 class StringsApi(ApiV2):
 
-    def __init__(self, userIdentifier, userSecret, projectId, proxySettings=None, permanentHeaders={}, env='prod'):
-        ApiV2.__init__(self, userIdentifier, userSecret, projectId, proxySettings, permanentHeaders=permanentHeaders, env=env)
+    def __init__(self, userIdentifier, userSecret, projectId, proxySettings=None, permanentHeaders={}, env='prod', ignore_errors=False):
+        ApiV2.__init__(self, userIdentifier, userSecret, projectId, proxySettings, permanentHeaders=permanentHeaders, env=env, ignore_errors=ignore_errors)
 
     def addStringsToProject(self, strings, placeholderFormat='', placeholderFormatCustom='', namespace='smartling.strings-api.default.namespace', **kwargs):
         """

--- a/smartlingApiSdk/api/TagsApi.py
+++ b/smartlingApiSdk/api/TagsApi.py
@@ -23,8 +23,8 @@ from smartlingApiSdk.ApiV2 import ApiV2
 
 class TagsApi(ApiV2):
 
-    def __init__(self, userIdentifier, userSecret, projectId, proxySettings=None, permanentHeaders={}, env='prod'):
-        ApiV2.__init__(self, userIdentifier, userSecret, projectId, proxySettings, permanentHeaders=permanentHeaders, env=env)
+    def __init__(self, userIdentifier, userSecret, projectId, proxySettings=None, permanentHeaders={}, env='prod', ignore_errors=False):
+        ApiV2.__init__(self, userIdentifier, userSecret, projectId, proxySettings, permanentHeaders=permanentHeaders, env=env, ignore_errors=ignore_errors)
 
     def getTagsListByAccount(self, accountUid, projectIds=[], tagMask='', limit=1500, offset=0, **kwargs):
         """


### PR DESCRIPTION
REF: #61 

In smartlingApiSdk/FileApiBase.py, the commandJson method contains a print statement that is executed whenever an API call returns a non-successful status code (i.e., not 200 or 202).

Currently, this print statement is executed regardless of whether the ignore_errors flag is present in the request parameters. This leads to unwanted console output even when errors are being handled gracefully by the calling application.

The print statement should only be executed if the ignore_errors flag is False. The method should check for the ignore_errors parameter and use its value to conditionally suppress the error message.

This change ensures that the behavior of commandJson is consistent with the ignore_errors flag, allowing developers to have cleaner logs when they are programmatically handling API errors.